### PR TITLE
Favourite team feature

### DIFF
--- a/favteam.py
+++ b/favteam.py
@@ -118,6 +118,14 @@ def getCurrentMonday():
     return tday - timedelta(tday.isoweekday() - 1) # start on Monday
 
 def favTeamMenu():
+    if vars.fav_team is None:
+        xbmcgui.Dialog().ok(vars.__addon_name__, 'Set your favourite team in the settings')
+        xbmcaddon.Addon().openSettings()
+        vars.updateFavTeam()
+        if vars.fav_team is None:
+            addListItem('Set your favourite team in the settings', '', 'favteam', '', False)
+            return
+
     log("Loading games for: " + vars.fav_team)
     tday = getCurrentMonday()
     addFavTeamGameLinks(tday, vars.fav_team, 'live')

--- a/favteam.py
+++ b/favteam.py
@@ -1,0 +1,141 @@
+import json
+import datetime, time
+from datetime import timedelta
+import urllib,urllib2
+import xbmc,xbmcplugin,xbmcgui
+from xml.dom.minidom import parseString
+import re
+import sys
+
+from utils import *
+from common import * 
+import vars
+
+def addFavTeamGameLinks(fromDate, favTeam, video_type = 'archive'):
+    try:
+        if type(fromDate) is datetime.datetime:
+            fromDate = "%04d/%d_%d" % (fromDate.year, fromDate.month, fromDate.day)
+        schedule = 'http://smb.cdnak.neulion.com/fs/nba/feeds_s2012/schedule/' + fromDate +  '.js?t=' + "%d"  %time.time()
+        log('Requesting %s' % schedule, xbmc.LOGDEBUG)
+
+        now_datetime_est = nowEST()
+
+        # http://smb.cdnak.neulion.com/fs/nba/feeds_s2012/schedule/2013/10_7.js?t=1381054350000
+        req = urllib2.Request(schedule, None);
+        response = str(urllib2.urlopen(req).read())
+        js = json.loads(response[response.find("{"):])
+
+        for game in reversed(js['games']):
+            log(game, xbmc.LOGDEBUG)
+            for details in game:
+                h = details.get('h', '')
+                v = details.get('v', '')
+                game_id = details.get('id', '')
+                game_start_date_est = details.get('d', '')
+                vs = details.get('vs', '')
+                hs = details.get('hs', '')
+                gs = details.get('gs', '')
+
+                video_has_away_feed = False
+                video_details = details.get('video', {})
+                video_has_away_feed = video_details.get("af", False)
+
+                # Try to convert start date to datetime
+                try:
+                    game_start_datetime_est = datetime.datetime.strptime(game_start_date_est, "%Y-%m-%dT%H:%M:%S.%f" )
+                except:
+                    game_start_datetime_est = datetime.datetime.fromtimestamp(time.mktime(time.strptime(game_start_date_est, "%Y-%m-%dT%H:%M:%S.%f")))
+
+                #Set game start date in the past if python can't parse the date
+                #so it doesn't get flagged as live or future game and you can still play it
+                #if a video is available
+                if type(game_start_datetime_est) is not datetime.datetime:
+                    game_start_datetime_est = now_datetime_est + timedelta(-30)
+
+                #guess end date by adding 4 hours to start date
+                game_end_datetime_est = game_start_datetime_est + timedelta(hours=4)
+
+                if game_id != '' and (v.lower() == favTeam or h.lower() == favTeam):
+                    # Get pretty names for the team names
+                    if v.lower() in vars.teams:
+                        visitor_name = vars.teams[v.lower()]
+                    else:
+                        visitor_name = v
+                    if h.lower() in vars.teams:
+                        host_name = vars.teams[h.lower()]
+                    else:
+                        host_name = h
+
+                    has_video = "video" in details
+                    future_video = game_start_datetime_est > now_datetime_est and \
+                        game_start_datetime_est.date() == now_datetime_est.date()
+                    live_video = game_start_datetime_est < now_datetime_est < game_end_datetime_est
+
+                    # Create the title
+                    name = game_start_datetime_est.strftime("%Y-%m-%d")
+                    if video_type == "live":
+                        name = toLocalTimezone(game_start_datetime_est).strftime("%Y-%m-%d (at %I:%M %p)")
+
+                    #Add the teams' names and the scores if needed
+                    name += ' %s vs %s' % (visitor_name, host_name)
+                    if vars.scores == '1' and not future_video:
+                        name += ' %s:%s' % (str(vs), str(hs))
+
+                    thumbnail_url = ("http://e1.cdnl3.neulion.com/nba/player-v4/nba/images/teams/%s.png" % h)
+
+                    if video_type == "live":
+                        if future_video:
+                            name = "UPCOMING: " + name
+                        elif live_video:
+                            name = "LIVE: " + name
+
+                    add_link = True
+                    if video_type == "live" and not (live_video or future_video):
+                        add_link = False
+                    elif video_type != "live" and (live_video or future_video):
+                        add_link = False
+                    elif not future_video and not has_video:
+                        add_link = False
+
+                    if add_link == True:
+                        awayFeed = video_has_away_feed and favTeam == v.lower()
+                        params = {
+                            'video_id': game_id,
+                            'video_type': video_type,
+                            'video_ishomefeed': 0 if awayFeed else 1
+                        }
+                        name = name + (' (away)' if awayFeed else ' (home)')
+                                
+                        addListItem(name, url="", mode="playgame", iconimage="", customparams=params)
+
+    except Exception, e:
+        xbmc.executebuiltin('Notification(NBA League Pass,'+str(e)+',5000,)')
+        log(str(e))
+        pass
+
+def getCurrentMonday():
+    tday = nowEST()
+    return tday - timedelta(tday.isoweekday() - 1) # start on Monday
+
+def favTeamMenu():
+    log("Loading games for: " + vars.fav_team)
+    tday = getCurrentMonday()
+    addFavTeamGameLinks(tday, vars.fav_team, 'live')
+    weeksBack = 0
+    while monthIsInSeason(tday.month) and weeksBack < 3:
+        addFavTeamGameLinks(tday, vars.fav_team)
+        tday = tday - timedelta(7)
+        weeksBack = weeksBack + 1
+
+    if tday.month >= 10:
+        addListItem('Older games', 'older', 'favteam', '', True)
+
+def favTeamOlderMenu():
+    log("Loading older games for: " + vars.fav_team)
+    tday = getCurrentMonday() - timedelta(14)
+    while monthIsInSeason(tday.month):
+        addFavTeamGameLinks(tday, vars.fav_team)
+        tday = tday - timedelta(7)
+
+def monthIsInSeason(month):
+    return month >= 10 or month <= 6

--- a/leaguepass.py
+++ b/leaguepass.py
@@ -9,6 +9,7 @@ from games import *
 from common import *
 from videos import *
 from nbatvlive import LiveTV
+from favteam import *
 import vars
 
 log("Chosen quality_id %s and target_video_height %d" % (vars.quality_id, vars.target_video_height))
@@ -20,6 +21,8 @@ def mainMenu():
     if isLiveUsable():
         addListItem('NBA TV Live', '', 'nbatvlivemenu','', True)
     addListItem('Video', '', 'video', '', True)
+    if vars.fav_team:
+        addListItem(vars.teams[vars.fav_team.lower()] + ' games', '', 'favteam', '', True)
 
 def archiveMenu():
     addListItem('This week', "archive", 'thisweek' ,'', True)
@@ -99,6 +102,11 @@ elif mode == "nbatvliveepisodemenu":
     LiveTV.episodeMenu()
 elif mode == "nbatvliveepisode":
     LiveTV.playEpisode()
+elif mode == "favteam":
+    if url == "older":
+        favTeamOlderMenu()
+    else:
+        favTeamMenu()
 else:
     chooseGameMenu(mode, url)
 

--- a/leaguepass.py
+++ b/leaguepass.py
@@ -21,8 +21,7 @@ def mainMenu():
     if isLiveUsable():
         addListItem('NBA TV Live', '', 'nbatvlivemenu','', True)
     addListItem('Video', '', 'video', '', True)
-    if vars.fav_team:
-        addListItem(vars.teams[vars.fav_team.lower()] + ' games', '', 'favteam', '', True)
+    addListItem('Favourite team\'s games', '', 'favteam', '', True)
 
 def archiveMenu():
     addListItem('This week', "archive", 'thisweek' ,'', True)

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -42,11 +42,11 @@ msgid "Show Live games in local timezone"
 msgstr ""
 
 msgctxt "#50008"
-msgid "Favourite Team"
+msgid "next page..."
 msgstr ""
 
-msgctxt "#50008"
-msgid "next page..."
+msgctxt "#50009"
+msgid "Favourite Team"
 msgstr ""
 
 msgctxt "#50020"
@@ -64,3 +64,124 @@ msgstr ""
 msgctxt "#50023"
 msgid "Failed to get video URL (response != 200)"
 msgstr ""
+
+msgctxt "#50100"
+msgid "Nets"
+msgstr ""
+
+msgctxt "#50101"
+msgid "Knicks"
+msgstr ""
+
+msgctxt "#50102"
+msgid "Hawks"
+msgstr ""
+
+msgctxt "#50103"
+msgid "Wizards"
+msgstr ""
+
+msgctxt "#50104"
+msgid "Sixers"
+msgstr ""
+
+msgctxt "#50105"
+msgid "Celtics"
+msgstr ""
+
+msgctxt "#50106"
+msgid "Bulls"
+msgstr ""
+
+msgctxt "#50107"
+msgid "Timberwolves"
+msgstr ""
+
+msgctxt "#50108"
+msgid "Bucks"
+msgstr ""
+
+msgctxt "#50109"
+msgid "Bobcats"
+msgstr ""
+
+msgctxt "#50110"
+msgid "Mavericks"
+msgstr ""
+
+msgctxt "#50111"
+msgid "Clippers"
+msgstr ""
+
+msgctxt "#50112"
+msgid "Lakers"
+msgstr ""
+
+msgctxt "#50113"
+msgid "Spurs"
+msgstr ""
+
+msgctxt "#50114"
+msgid "Thunder"
+msgstr ""
+
+msgctxt "#50115"
+msgid "Pelicans"
+msgstr ""
+
+msgctxt "#50116"
+msgid "Blazers"
+msgstr ""
+
+msgctxt "#50117"
+msgid "Grizzlies"
+msgstr ""
+
+msgctxt "#50118"
+msgid "Heat"
+msgstr ""
+
+msgctxt "#50119"
+msgid "Magic"
+msgstr ""
+
+msgctxt "#50120"
+msgid "Kings"
+msgstr ""
+
+msgctxt "#50121"
+msgid "Raptors"
+msgstr ""
+
+msgctxt "#50122"
+msgid "Pacers"
+msgstr ""
+
+msgctxt "#50123"
+msgid "Pistons"
+msgstr ""
+
+msgctxt "#50124"
+msgid "Cavaliers"
+msgstr ""
+
+msgctxt "#50125"
+msgid "Nuggets"
+msgstr ""
+
+msgctxt "#50126"
+msgid "Jazz"
+msgstr ""
+
+msgctxt "#50127"
+msgid "Suns"
+msgstr ""
+
+msgctxt "#50128"
+msgid "Warriors"
+msgstr ""
+
+msgctxt "#50129"
+msgid "Rockets"
+msgstr ""
+

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -42,6 +42,10 @@ msgid "Show Live games in local timezone"
 msgstr ""
 
 msgctxt "#50008"
+msgid "Favourite Team"
+msgstr ""
+
+msgctxt "#50008"
 msgid "next page..."
 msgstr ""
 

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -66,122 +66,126 @@ msgid "Failed to get video URL (response != 200)"
 msgstr ""
 
 msgctxt "#50100"
-msgid "Nets"
+msgid "None"
 msgstr ""
 
 msgctxt "#50101"
-msgid "Knicks"
+msgid "Nets"
 msgstr ""
 
 msgctxt "#50102"
-msgid "Hawks"
+msgid "Knicks"
 msgstr ""
 
 msgctxt "#50103"
-msgid "Wizards"
+msgid "Hawks"
 msgstr ""
 
 msgctxt "#50104"
-msgid "Sixers"
+msgid "Wizards"
 msgstr ""
 
 msgctxt "#50105"
-msgid "Celtics"
+msgid "Sixers"
 msgstr ""
 
 msgctxt "#50106"
-msgid "Bulls"
+msgid "Celtics"
 msgstr ""
 
 msgctxt "#50107"
-msgid "Timberwolves"
+msgid "Bulls"
 msgstr ""
 
 msgctxt "#50108"
-msgid "Bucks"
+msgid "Timberwolves"
 msgstr ""
 
 msgctxt "#50109"
-msgid "Bobcats"
+msgid "Bucks"
 msgstr ""
 
 msgctxt "#50110"
-msgid "Mavericks"
+msgid "Bobcats"
 msgstr ""
 
 msgctxt "#50111"
-msgid "Clippers"
+msgid "Mavericks"
 msgstr ""
 
 msgctxt "#50112"
-msgid "Lakers"
+msgid "Clippers"
 msgstr ""
 
 msgctxt "#50113"
-msgid "Spurs"
+msgid "Lakers"
 msgstr ""
 
 msgctxt "#50114"
-msgid "Thunder"
+msgid "Spurs"
 msgstr ""
 
 msgctxt "#50115"
-msgid "Pelicans"
+msgid "Thunder"
 msgstr ""
 
 msgctxt "#50116"
-msgid "Blazers"
+msgid "Pelicans"
 msgstr ""
 
 msgctxt "#50117"
-msgid "Grizzlies"
+msgid "Blazers"
 msgstr ""
 
 msgctxt "#50118"
-msgid "Heat"
+msgid "Grizzlies"
 msgstr ""
 
 msgctxt "#50119"
-msgid "Magic"
+msgid "Heat"
 msgstr ""
 
 msgctxt "#50120"
-msgid "Kings"
+msgid "Magic"
 msgstr ""
 
 msgctxt "#50121"
-msgid "Raptors"
+msgid "Kings"
 msgstr ""
 
 msgctxt "#50122"
-msgid "Pacers"
+msgid "Raptors"
 msgstr ""
 
 msgctxt "#50123"
-msgid "Pistons"
+msgid "Pacers"
 msgstr ""
 
 msgctxt "#50124"
-msgid "Cavaliers"
+msgid "Pistons"
 msgstr ""
 
 msgctxt "#50125"
-msgid "Nuggets"
+msgid "Cavaliers"
 msgstr ""
 
 msgctxt "#50126"
-msgid "Jazz"
+msgid "Nuggets"
 msgstr ""
 
 msgctxt "#50127"
-msgid "Suns"
+msgid "Jazz"
 msgstr ""
 
 msgctxt "#50128"
-msgid "Warriors"
+msgid "Suns"
 msgstr ""
 
 msgctxt "#50129"
+msgid "Warriors"
+msgstr ""
+
+msgctxt "#50130"
 msgid "Rockets"
 msgstr ""
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,6 @@
     <setting id="local_timezone" type="enum" label="50007" values="on|off" default="0" />
     <setting id="debug" type="enum" label="50005" values="on|off" default="1" />
     <setting id="fanart_image" type="text" label="50006" visible="false" default=""/>
+    <setting id="fav_team" type="text" label="50008" default="orl" />
   </category>
-
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,6 @@
     <setting id="local_timezone" type="enum" label="50007" values="on|off" default="0" />
     <setting id="debug" type="enum" label="50005" values="on|off" default="1" />
     <setting id="fanart_image" type="text" label="50006" visible="false" default=""/>
-    <setting id="fav_team" type="labelenum" label="50009" lvalues="50100|50101|50102|50103|50104|50105|50106|50107|50108|50109|50110|50111|50112|50113|50114|50115|50116|50117|50118|50119|50120|50121|50122|50123|50124|50125|50126|50127|50128|50129" />
+    <setting id="fav_team" type="labelenum" label="50009" lvalues="50100|50101|50102|50103|50104|50105|50106|50107|50108|50109|50110|50111|50112|50113|50114|50115|50116|50117|50118|50119|50120|50121|50122|50123|50124|50125|50126|50127|50128|50129|50130" />
   </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,6 @@
     <setting id="local_timezone" type="enum" label="50007" values="on|off" default="0" />
     <setting id="debug" type="enum" label="50005" values="on|off" default="1" />
     <setting id="fanart_image" type="text" label="50006" visible="false" default=""/>
-    <setting id="fav_team" type="text" label="50008" default="orl" />
+    <setting id="fav_team" type="labelenum" label="50009" lvalues="50100|50101|50102|50103|50104|50105|50106|50107|50108|50109|50110|50111|50112|50113|50114|50115|50116|50117|50118|50119|50120|50121|50122|50123|50124|50125|50126|50127|50128|50129" />
   </category>
 </settings>

--- a/utils.py
+++ b/utils.py
@@ -85,7 +85,7 @@ def addVideoListItem(name, url, iconimage):
 
 def addListItem(name, url, mode, iconimage, isfolder=False, usefullurl=False, customparams={}):
     if not hasattr(addListItem, "fanart_image"):
-        settings = xbmcaddon.Addon( id="plugin.video.nba")
+        settings = xbmcaddon.Addon( id=vars.__addon_id__)
         addListItem.fanart_image = settings.getSetting("fanart_image")
 
     params = {

--- a/vars.py
+++ b/vars.py
@@ -13,6 +13,7 @@ settings = xbmcaddon.Addon( id="plugin.video.nba")
 scores = settings.getSetting( id="scores")
 debug = settings.getSetting( id="debug")
 use_local_timezone = settings.getSetting( id="local_timezone") == "0"
+fav_team = settings.getSetting( id="fav_team")
 
 # map the quality_id to a video height
 # Ex: 720p

--- a/vars.py
+++ b/vars.py
@@ -13,7 +13,7 @@ settings = xbmcaddon.Addon( id="plugin.video.nba")
 scores = settings.getSetting( id="scores")
 debug = settings.getSetting( id="debug")
 use_local_timezone = settings.getSetting( id="local_timezone") == "0"
-fav_team = settings.getSetting( id="fav_team")
+fav_team_name = settings.getSetting( id="fav_team")
 
 # map the quality_id to a video height
 # Ex: 720p
@@ -83,3 +83,8 @@ teams = {
     'mos' : "UCKA Moscow",
     'mac' : "Maccabi Haifa",
 }
+
+if fav_team_name:
+    for abbr, name in teams.items():
+        if fav_team_name == name:
+            fav_team = abbr

--- a/vars.py
+++ b/vars.py
@@ -7,13 +7,13 @@ except:
     import storageserverdummy as StorageServer
 
 __addon_name__ = "NBA League Pass"
+__addon_id__ = "plugin.video.nba"
 
 # global variables
-settings = xbmcaddon.Addon( id="plugin.video.nba")
+settings = xbmcaddon.Addon( id=__addon_id__)
 scores = settings.getSetting( id="scores")
 debug = settings.getSetting( id="debug")
 use_local_timezone = settings.getSetting( id="local_timezone") == "0"
-fav_team_name = settings.getSetting( id="fav_team")
 
 # map the quality_id to a video height
 # Ex: 720p
@@ -34,7 +34,7 @@ cookies = ''
 player_id = binascii.b2a_hex(os.urandom(16))
 media_dir = os.path.join(
     xbmc.translatePath("special://home/" ), 
-    "addons", "plugin.video.nba"
+    "addons", __addon_id__
     # "resources", "media"
 )
 
@@ -84,7 +84,16 @@ teams = {
     'mac' : "Maccabi Haifa",
 }
 
-if fav_team_name:
-    for abbr, name in teams.items():
-        if fav_team_name == name:
-            fav_team = abbr
+def updateFavTeam():
+    global fav_team
+    global fav_team_name
+    fav_team = None
+    fav_team_name = settings.getSetting( id="fav_team")
+    if fav_team_name:
+        for abbr, name in teams.items():
+            if fav_team_name == name:
+                fav_team = abbr
+
+updateFavTeam()
+
+xbmc.log(msg="fav_team set to %s" % (fav_team), level=xbmc.LOGWARNING)


### PR DESCRIPTION
This is a simple favourite teams feature. The user sets their favourite team via the settings and an extra top level menu item is added. This leads to a menu providing any recent games which feature that team. The games are set to always use the favourite team's announcers (possibly should make that another option).

The last 3 week's worth of games are supplied and then older games can be accessed through another submenu.
