### PR TITLE
Fix for issue 46

### DIFF
--- a/common.py
+++ b/common.py
@@ -56,7 +56,7 @@ def getGameUrlWithBitrate(url, video_type):
 
         log("video of bitrate %d not found, trying with next height" % target_bitrate, xbmc.LOGDEBUG)
 
-    return selected_video_url
+    return "%s|User-Agent=%s" % (selected_video_url, vars.useragent)
 
 def getFanartImage():
     # get the feed url

--- a/games.py
+++ b/games.py
@@ -74,11 +74,11 @@ def getGameUrl(video_id, video_type, video_ishomefeed):
         url = "http://%s/%s?%s" % (domain, arguments, querystring)
         url = getGameUrlWithBitrate(url, video_type)
 
-        selected_video_url = "%s|Cookie=%s" % (url, livecookiesencoded)
+        selected_video_url = "%s&Cookie=%s" % (url, livecookiesencoded)
     else:
         # Archive and condensed flow: We now work with HLS. 
         # The cookies are already in the URL and the server will supply them to ffmpeg later.
-        selected_video_url = "%s|User-Agent=iTunes-AppleTV/4.1" % getGameUrlWithBitrate(url, video_type)
+        selected_video_url = getGameUrlWithBitrate(url, video_type)
         
         
     if selected_video_url:

--- a/games.py
+++ b/games.py
@@ -78,7 +78,7 @@ def getGameUrl(video_id, video_type, video_ishomefeed):
     else:
         # Archive and condensed flow: We now work with HLS. 
         # The cookies are already in the URL and the server will supply them to ffmpeg later.
-        selected_video_url = getGameUrlWithBitrate(url, video_type)
+        selected_video_url = "%s|User-Agent=iTunes-AppleTV/4.1" % getGameUrlWithBitrate(url, video_type)
         
         
     if selected_video_url:

--- a/nbatvlive.py
+++ b/nbatvlive.py
@@ -106,7 +106,7 @@ class LiveTV:
         livecookiesencoded = urllib.quote(livecookies)
         log("live cookie: %s %s" % (querystring, livecookies), xbmc.LOGDEBUG)
 
-        video_url = "http://%s/%s?%s|Cookie=%s" % (domain, arguments, querystring, livecookiesencoded)
+        video_url = "http://%s/%s?%s|User-Agent=%s&Cookie=%s" % (domain, arguments, querystring, vars.useragent, livecookiesencoded)
         item = xbmcgui.ListItem(path=video_url)
         xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, item)
 
@@ -165,7 +165,7 @@ class LiveTV:
             livecookiesencoded = urllib.quote(livecookies)
             log("live cookie: %s %s" % (querystring, livecookies), xbmc.LOGDEBUG)
 
-            video_url = "http://%s/%s?%s|Cookie=%s" % (domain, arguments, querystring, livecookiesencoded)
+            video_url = "http://%s/%s?%s|User-Agent=%s&Cookie=%s" % (domain, arguments, querystring, vars.useragent, livecookiesencoded)
         else:
             # Transform the link from adaptive://domain/url?querystring to
             # http://domain/play?url=url&querystring
@@ -228,8 +228,8 @@ class LiveTV:
                         # break from the video quality loop
                         break
 
-            # Add the cookies in the format "videourl|Cookie=[cookies]""
-            video_url = "%s?%s|Cookie=%s" % (video_url, querystring, video_cookies_encoded)
+            # Add the cookies in the format "videourl|User-Agent=[useragent]&Cookie=[cookies]""
+            video_url = "%s?%s|User-Agent=%s&Cookie=%s" % (video_url, querystring, vars.useragent, video_cookies_encoded)
 
         item = xbmcgui.ListItem(path=video_url)
         xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, item)

--- a/vars.py
+++ b/vars.py
@@ -14,6 +14,7 @@ settings = xbmcaddon.Addon( id="plugin.video.nba")
 scores = settings.getSetting( id="scores")
 debug = settings.getSetting( id="debug")
 use_local_timezone = settings.getSetting( id="local_timezone") == "0"
+useragent = "iTunes-AppleTV/4.1"
 
 # map the quality_id to a video height
 # Ex: 720p


### PR DESCRIPTION
Fixes #46 inline with @kaileu suggestion
Sets the User-Agent used by FFMpeg to the AppleTV useragent string, as the default Kodi useragent string appears to blocked.