### PR TITLE
Added option to hide additional camera feeds

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -53,6 +53,10 @@ msgctxt "#50010"
 msgid "Use cached thumbnails"
 msgstr ""
 
+msgctxt "#50011"
+msgid "Show additional camera feeds"
+msgstr ""
+
 msgctxt "#50020"
 msgid "Failed to get a video URL. Are you logged in?"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,5 +13,6 @@
 		<setting id="cached_thumbnails" type="bool" label="50010" default="true" />
 		<setting id="debug" type="bool" label="50005" default="false" />
 		<setting id="fanart_image" type="text" label="50006" visible="false" default="" />
+		<setting id="cameras" type="bool" label="50011" default="true" />
 	</category>
 </settings>

--- a/src/games.py
+++ b/src/games.py
@@ -356,25 +356,27 @@ def chooseGameVideoMenu():
         }
         addListItem("Full game", url="", mode="playgame", iconimage="", customparams=params)
 
-    #Add all the cameras available
-    for camera_number in game_cameras:
-        #Skip camera number 0 (broadcast?) - the full game links are the same
-        camera_number = int(camera_number)
-        if camera_number == 0:
-            continue
+    if vars.show_cameras:
+		
+        #Add all the cameras available
+        for camera_number in game_cameras:
+            #Skip camera number 0 (broadcast?) - the full game links are the same
+            camera_number = int(camera_number)
+            if camera_number == 0:
+                continue
 
-        params = {
-            'video_id': video_id,
-            'video_type': video_type,
-            'game_state': game_state,
-            'camera_number': camera_number,
-            'start_time': start_time,
-            'duration': duration,
-        }
+            params = {
+                'video_id': video_id,
+                'video_type': video_type,
+                'game_state': game_state,
+                'camera_number': camera_number,
+                'start_time': start_time,
+                'duration': duration,
+            }
 
-        name = "Camera %d: %s" % (camera_number, nba_cameras[camera_number])
-        addListItem(name
-            , url="", mode="playgame", iconimage="", customparams=params)
+            name = "Camera %d: %s" % (camera_number, nba_cameras[camera_number])
+            addListItem(name
+                , url="", mode="playgame", iconimage="", customparams=params)
 
     #Live games have no condensed or highlight link
     if video_type != "live":

--- a/src/vars.py
+++ b/src/vars.py
@@ -16,6 +16,7 @@ show_scores = json.loads(settings.getSetting(id="scores"))
 debug = json.loads(settings.getSetting(id="debug"))
 use_cached_thumbnails = json.loads(settings.getSetting(id="cached_thumbnails"))
 use_local_timezone = json.loads(settings.getSetting(id="local_timezone"))
+show_cameras = json.loads(settings.getSetting(id="cameras"))
 useragent = "iTunes-AppleTV/4.1"
 
 # map the quality_id to a video height


### PR DESCRIPTION
Allows the extra camera feeds (which I have never used) to be hidden. Defaults to showing them so functionality remains the same as it is now unless the user specifically turns the option off.